### PR TITLE
fix: Normalize ratings to prevent inter-generational drift

### DIFF
--- a/src/rankers/glicko_rank.py
+++ b/src/rankers/glicko_rank.py
@@ -42,6 +42,7 @@ class Story:
     rd: float = 350.0
     sigma: float = 0.06
     
+    previous_batch_rating: Optional[float] = None
     matches_played: int = 0
     wins: int = 0
     losses: int = 0
@@ -318,6 +319,7 @@ def load_stories_from_json(json_path: str, default_rating: float, default_rd: fl
             rating=story_data.get("rating", story_data.get("elo", default_rating)),
             rd=story_data.get("rd", default_rd),
             sigma=story_data.get("sigma", default_sigma),
+            previous_batch_rating=story_data.get("previous_batch_rating"),
             matches_played=story_data.get("matches_played", 0),
             wins=story_data.get("wins", 0),
             losses=story_data.get("losses", 0)

--- a/src/rankers/tournament_runner.py
+++ b/src/rankers/tournament_runner.py
@@ -126,7 +126,22 @@ class TournamentRunner:
             original_prompt=original_prompt
         )
         
-        print("\nTournament Complete! {len(matches_played)} matches played")
+        parent_stories = [s for s in stories if hasattr(s, 'previous_batch_rating') and s.previous_batch_rating is not None]
+
+        if parent_stories:
+            print("\n🔄 Normalizing ratings to prevent score drift...")
+            rating_diffs = [s.rating - s.previous_batch_rating for s in parent_stories]
+            
+            if rating_diffs:
+                average_drift = sum(rating_diffs) / len(rating_diffs)
+                print(f"  - Average rating drift of parents: {average_drift:+.1f} points.")
+                
+                for story in stories:
+                    story.rating -= average_drift
+                    story._mu = (story.rating - 1500) / 173.7178
+                print(f"  - All {len(stories)} story ratings in this batch have been adjusted to compensate.")
+        
+        print(f"\nTournament Complete! {matches_played} matches played")
         print("\nFinal Glicko Standings:")
         
         leaderboard = glicko_system.get_leaderboard(stories)


### PR DESCRIPTION
When top-performing "parent" stories are carried over into subsequent tournaments with their new "child" variants, their Glicko ratings can drift significantly. If the new generation is stronger on average, the parents' ratings will drop, and vice-versa. This creates "rating drift," making it impossible to compare scores meaningfully across different evolutionary generations. This doesn't negatively affect the end product, but it is bad for users and may pose a roadblock in further development.

This commit introduces a rating normalization step to solve this problem. After each tournament concludes, the system now performs the following actions:

1.  Identifies all parent stories that were carried over from the previous batch.
2.  Calculates the average rating change (the "drift") for these parents compared to their ratings from the end of the last tournament.
3.  Subtracts this average drift from the final Glicko ratings of *all* stories in the current batch (both parents and their children).

This change effectively re-anchors the rating scale of each new generation to the scale of the previous one, ensuring the long-term stability and comparability of the Glicko scores throughout the entire evolution process.

Technical Changes:
- 'src/rankers/tournament_runner.py': Implemented the core normalization logic after the Glicko updates but before results are saved.
- 'src/rankers/glicko_rank.py': The Story object now includes an optional previous_batch_rating field to track scores across tournaments.