### PR TITLE
Refactor: Migrate to SQLite, Fix Pipeline Flow, and Add Final Export

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,6 +22,11 @@
       "type": "openai_compatible",
       "api_key_env": "GEMINI_API_KEY",
       "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"
+    },
+    "koboldcpp": {
+      "type": "openai_compatible",
+      "api_key_env": "",
+      "base_url": "http://localhost:5001/v1/"
     }
   },
   "model_provider_mapping": {
@@ -31,38 +36,37 @@
     "claude-3-haiku-20240307": "anthropic",
     "meta-llama/Meta-Llama-3-70B-Instruct": "deepinfra",
     "deepseek-chat": "deepseek",
-    "gemini-2.5-flash": "gemini"
+    "gemini-2.5-flash": "gemini",
+    "Qwen3": "koboldcpp"
   },
   "batch_generation": {
-    "num_stories": 60,
-    "model": "gpt-4o",
+    "num_stories": 15,
+    "model": "Qwen3",
     "max_attempts": 3,
     "glicko_initial_rating": 1500,
     "glicko_initial_rd": 350,
     "glicko_initial_volatility": 0.06,
-    "max_concurrent_generations": 0
+    "max_concurrent_generations": 1
   },
   "next_batch_generation": {
-    "top_stories_to_select": 5,
-    "variants_per_story": 5,
-    "model": "gpt-4o",
+    "top_stories_to_select": 3,
+    "variants_per_story": 3,
+    "model": "Qwen3",
     "max_attempts": 3,
     "include_original_stories": true,
     "variant_temperature": 1.2,
-    "max_concurrent_generations": 0
+    "max_concurrent_generations": 1
   },
   "glicko_ranking": {
     "tau": 0.5,
-    "judge_model": "gpt-4o",
-    "tournament_rounds": 20,
-    "max_concurrent_matches": 60,
+    "judge_model": "Qwen3",
+    "tournament_rounds": 10,
+    "max_concurrent_matches": 1,
     "save_match_history": true,
     "update_rankings_after_each_round": true
   },
   "evolution_pipeline": {
     "max_iterations": 5,
-    "generate_final_batch": true,
-    "auto_continue_from_existing": true,
     "log_level": "INFO"
   },
   "input_files": {
@@ -71,9 +75,6 @@
   },
   "output": {
     "directory": "output",
-    "stories_file": "initial_stories.json",
-    "next_batch_file": "batch2_stories.json",
-    "elo_results_file": "glicko_rankings.json",
-    "match_history_file": "match_history.json"
+    "database_file": "alphaevolve.db"
   }
 }

--- a/src/rankers/__init__.py
+++ b/src/rankers/__init__.py
@@ -1,6 +1,6 @@
 """Ranking and tournament components."""
 
-from .glicko_rank import GlickoRankingSystem, load_stories_from_json
+from .glicko_rank import GlickoRankingSystem
 from .tournament_runner import TournamentRunner
 
-__all__ = ["GlickoRankingSystem", "load_stories_from_json", "TournamentRunner"]
+__all__ = ["GlickoRankingSystem", "TournamentRunner"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions and helpers."""
 
 from .inference import generate_text
+from .database import get_connection, create_schema, wipe_database, get_db_path
 
-__all__ = ["generate_text"]
+__all__ = ["generate_text", "get_connection", "create_schema", "wipe_database", "get_db_path"]

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -1,0 +1,102 @@
+"""Database utility functions for SQLite."""
+
+import sqlite3
+import os
+from typing import Dict, Any
+
+DB_PATH = None
+
+def get_db_path(config: Dict[str, Any]) -> str:
+    """Gets the database path from config, ensuring it's a singleton."""
+    global DB_PATH
+    if DB_PATH is None:
+        output_dir = config["output"]["directory"]
+        db_file = config["output"]["database_file"]
+        DB_PATH = os.path.join(output_dir, db_file)
+    return DB_PATH
+
+def get_connection(db_path: str) -> sqlite3.Connection:
+    """Get a connection to the SQLite database."""
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def create_schema(conn: sqlite3.Connection):
+    """Create the database schema if it doesn't exist."""
+    cursor = conn.cursor()
+    cursor.executescript("""
+        CREATE TABLE IF NOT EXISTS stories (
+            story_id TEXT PRIMARY KEY,
+            batch_number INTEGER NOT NULL,
+            piece TEXT NOT NULL,
+            prompt TEXT,
+            model_used TEXT,
+            rating REAL,
+            rd REAL,
+            sigma REAL,
+            created_at TEXT,
+            generation_type TEXT,
+            parent_story_id TEXT,
+            matches_played INTEGER DEFAULT 0,
+            wins INTEGER DEFAULT 0,
+            losses INTEGER DEFAULT 0,
+            previous_batch_rating REAL,
+            FOREIGN KEY (parent_story_id) REFERENCES stories (story_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS matches (
+            match_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            story1_id TEXT NOT NULL,
+            story2_id TEXT NOT NULL,
+            winner_id TEXT NOT NULL,
+            story1_rating_before REAL,
+            story2_rating_before REAL,
+            story1_rating_after REAL,
+            story2_rating_after REAL,
+            reasoning TEXT,
+            timestamp TEXT,
+            FOREIGN KEY (story1_id) REFERENCES stories (story_id),
+            FOREIGN KEY (story2_id) REFERENCES stories (story_id),
+            FOREIGN KEY (winner_id) REFERENCES stories (story_id)
+        );
+        
+        CREATE TABLE IF NOT EXISTS human_preferences (
+            preference_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            story1_id TEXT NOT NULL,
+            story2_id TEXT NOT NULL,
+            preferred_story_id TEXT NOT NULL,
+            user_session TEXT,
+            batch1_name TEXT,
+            batch2_name TEXT,
+            preferred_batch_name TEXT,
+            FOREIGN KEY (story1_id) REFERENCES stories (story_id),
+            FOREIGN KEY (story2_id) REFERENCES stories (story_id),
+            FOREIGN KEY (preferred_story_id) REFERENCES stories (story_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS judge_tests (
+            test_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            story1_id TEXT NOT NULL,
+            story2_id TEXT NOT NULL,
+            user_prediction_id TEXT NOT NULL,
+            llm_winner_id TEXT NOT NULL,
+            correct BOOLEAN,
+            user_session TEXT,
+            FOREIGN KEY (story1_id) REFERENCES stories (story_id),
+            FOREIGN KEY (story2_id) REFERENCES stories (story_id),
+            FOREIGN KEY (user_prediction_id) REFERENCES stories (story_id),
+            FOREIGN KEY (llm_winner_id) REFERENCES stories (story_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_stories_batch ON stories (batch_number);
+        CREATE INDEX IF NOT EXISTS idx_matches_winner ON matches (winner_id);
+    """)
+    conn.commit()
+
+def wipe_database(db_path: str):
+    """Wipe the database file by deleting it."""
+    if os.path.exists(db_path):
+        os.remove(db_path)

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -8,75 +8,73 @@ human preferences to validate the evolutionary story generation process.
 import json
 import os
 import random
-import glob
+import re
+import sqlite3
 import sys
 from datetime import datetime
-from typing import List, Dict, Any, Tuple
-from flask import Flask, render_template, request, jsonify, redirect, url_for
+from typing import List, Dict, Any, Tuple, Optional
+from flask import Flask, render_template, request, jsonify, redirect, url_for, g
 
 app = Flask(__name__)
 
 # Add parent directory to path to access story files
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Global variables for story data
-story_batches = {}
-preference_data = []
-current_comparison = None
-judge_test_data = []
-current_judge_test = None
+DB_PATH = "../output/alphaevolve.db"
 
-def load_all_batches() -> Dict[str, List[Dict[str, Any]]]:
-    """Load all story batch files from the output directory."""
-    batch_files = {}
-    output_dir = "../output"  # Relative to web_interface folder
-    
-    # Find all story batch files
-    pattern = os.path.join(output_dir, "*stories.json")
-    files = glob.glob(pattern)
-    
-    for file_path in files:
-        try:
-            with open(file_path, 'r') as f:
-                data = json.load(f)
-            
-            batch_name = os.path.basename(file_path).replace('.json', '')
-            stories = data.get('stories', [])
-            
-            if stories:
-                batch_files[batch_name] = stories
-                print(f"Loaded {len(stories)} stories from {batch_name}")
-        
-        except Exception as e:
-            print(f"Error loading {file_path}: {e}")
-    
-    return batch_files
+def get_db() -> sqlite3.Connection:
+    """Opens a new database connection if there is none yet for the current application context."""
+    if 'db' not in g:
+        g.db = sqlite3.connect(DB_PATH, detect_types=sqlite3.PARSE_DECLTYPES)
+        g.db.row_factory = sqlite3.Row
+    return g.db
 
-def get_top_stories_from_batch(batch_name: str, top_k: int = 5) -> List[Dict[str, Any]]:
-    """Get top K stories from a batch based on Glicko rating."""
-    stories = story_batches.get(batch_name, [])
-    if not stories:
-        return []
-    
-    # Sort by rating (highest first), fallback to 1500 if no rating
-    sorted_stories = sorted(stories, key=lambda s: s.get("rating", 1500), reverse=True)
-    return sorted_stories[:top_k]
+@app.teardown_appcontext
+def close_db(e=None):
+    """Closes the database again at the end of the request."""
+    db = g.pop('db', None)
+    if db is not None:
+        db.close()
+
+def get_batch_names() -> List[str]:
+    """
+    Get all unique batch names from the database, formatted for display.
+    DB batch_number 0 -> 'initial_stories'
+    DB batch_number 1 -> 'batch2_stories', etc.
+    """
+    cursor = get_db().cursor()
+    cursor.execute("SELECT DISTINCT batch_number FROM stories ORDER BY batch_number")
+    rows = cursor.fetchall()
+    return [f"{'initial_stories' if r['batch_number'] == 0 else f'batch{r['batch_number'] + 1}_stories'}" for r in rows]
+
+def get_batch_number_from_name(batch_name: str) -> int:
+    """
+    Convert a display batch name string to its integer number for DB queries.
+    'initial_stories' -> 0
+    'batch2_stories' -> 1, etc.
+    """
+    if "initial" in batch_name:
+        return 0
+    match = re.search(r'batch(\d+)', batch_name)
+    if match:
+        return int(match.group(1)) - 1
+    raise ValueError(f"Could not parse batch number from name: {batch_name}")
+
 
 def get_stories_for_comparison(batch_name: str) -> List[Dict[str, Any]]:
-    """Get stories for comparison - all stories for initial batch, top 5 for evolved batches."""
-    stories = story_batches.get(batch_name, [])
-    if not stories:
-        return []
+    """Get stories for comparison: all for initial, top 5 for evolved batches."""
+    batch_number = get_batch_number_from_name(batch_name)
+    cursor = get_db().cursor()
     
     if "initial" in batch_name.lower():
-        return stories
+        cursor.execute("SELECT * FROM stories WHERE batch_number = ?", (batch_number,))
+    else:
+        cursor.execute("SELECT * FROM stories WHERE batch_number = ? ORDER BY rating DESC LIMIT 5", (batch_number,))
     
-    # For evolved batches (batch2, etc.), use top 5 rated stories
-    sorted_stories = sorted(stories, key=lambda s: s.get("rating", 1500), reverse=True)
-    return sorted_stories[:5]
+    return [dict(row) for row in cursor.fetchall()]
 
 def get_random_story_pair(batch1_name: str, batch2_name: str) -> Tuple[Dict[str, Any], Dict[str, Any], str, str]:
-    """Get a random story pair - any story from initial batch, top 5 from evolved batches."""
+    """Get a random story pair for comparison."""
     batch1_stories = get_stories_for_comparison(batch1_name)
     batch2_stories = get_stories_for_comparison(batch2_name)
     
@@ -88,200 +86,71 @@ def get_random_story_pair(batch1_name: str, batch2_name: str) -> Tuple[Dict[str,
     
     return story1, story2, batch1_name, batch2_name
 
-def save_preference(story1_id: str, story2_id: str, batch1: str, batch2: str, 
-                   preferred_story: str, user_session: str) -> None:
-    """Save a user preference to the preference data."""
-    preference = {
-        "timestamp": datetime.now().isoformat(),
-        "story1_id": story1_id,
-        "story2_id": story2_id,
-        "batch1": batch1,
-        "batch2": batch2,
-        "preferred_story": preferred_story,  # "story1" or "story2"
-        "preferred_batch": batch1 if preferred_story == "story1" else batch2,
-        "user_session": user_session
-    }
-    
-    preference_data.append(preference)
-    
-    os.makedirs("../output", exist_ok=True)
-    
-    preference_file_data = {
-        "last_updated": datetime.now().isoformat(),
-        "total_preferences": len(preference_data),
-        "preferences": preference_data
-    }
-    
-    with open("../output/preference_data.json", "w") as f:
-        json.dump(preference_file_data, f, indent=2, ensure_ascii=False)
-    
-    save_live_percentages()
-
-def save_live_percentages() -> None:
-    """Save live percentage statistics for easy viewing."""
-    batch_names = list(story_batches.keys())
-    live_stats = {
-        "last_updated": datetime.now().isoformat(),
-        "total_preferences": len(preference_data),
-        "batch_comparisons": {}
-    }
-    
-    for i, batch1 in enumerate(batch_names):
-        for batch2 in batch_names[i+1:]:
-            key = f"{batch1}_vs_{batch2}"
-            stats = calculate_batch_stats(batch1, batch2)
-            live_stats["batch_comparisons"][key] = {
-                "batch1": batch1,
-                "batch2": batch2,
-                "total_comparisons": stats["total_comparisons"],
-                "batch1_wins": stats["batch1_wins"],
-                "batch2_wins": stats["batch2_wins"],
-                "batch1_percentage": stats["batch1_percentage"],
-                "batch2_percentage": stats["batch2_percentage"]
-            }
-    
-    with open("../output/live_percentages.json", "w") as f:
-        json.dump(live_stats, f, indent=2)
-
-def load_preferences() -> None:
-    """Load existing preference data if available."""
-    global preference_data
-    
-    try:
-        with open("../output/preference_data.json", "r") as f:
-            data = json.load(f)
-        
-        if isinstance(data, list):
-            preference_data = data
-        elif isinstance(data, dict) and "preferences" in data:
-            preference_data = data["preferences"]
-        else:
-            preference_data = []
-            
-        print(f"Loaded {len(preference_data)} existing preferences")
-    except FileNotFoundError:
-        preference_data = []
-        print("No existing preference data found")
-
-def load_match_history() -> List[Dict[str, Any]]:
-    """Load match history from the Glicko tournament."""
-    try:
-        with open("../output/match_history.json", "r") as f:
-            data = json.load(f)
-        
-        if isinstance(data, dict) and "matches" in data:
-            return data["matches"]
-        elif isinstance(data, list):
-            return data
-        else:
-            return []
-    except FileNotFoundError:
-        return []
-
-def load_judge_test_data() -> None:
-    """Load existing judge test data if available."""
-    global judge_test_data
-    
-    try:
-        with open("../output/judge_test_data.json", "r") as f:
-            data = json.load(f)
-        
-        if isinstance(data, dict) and "tests" in data:
-            judge_test_data = data["tests"]
-        elif isinstance(data, list):
-            judge_test_data = data
-        else:
-            judge_test_data = []
-            
-        print(f"Loaded {len(judge_test_data)} existing judge tests")
-    except FileNotFoundError:
-        judge_test_data = []
-        print("No existing judge test data found")
-
-def save_judge_test(user_prediction: str, llm_winner: str, story1_id: str, story2_id: str, user_session: str) -> None:
-    """Save a judge test result."""
-    test_result = {
-        "timestamp": datetime.now().isoformat(),
-        "story1_id": story1_id,
-        "story2_id": story2_id,
-        "user_prediction": user_prediction,  # "story1" or "story2"
-        "llm_winner": llm_winner,  # "story1" or "story2"
-        "correct": user_prediction == llm_winner,
-        "user_session": user_session
-    }
-    
-    judge_test_data.append(test_result)
-    
-    os.makedirs("../output", exist_ok=True)
-    
-    judge_test_file_data = {
-        "last_updated": datetime.now().isoformat(),
-        "total_tests": len(judge_test_data),
-        "correct_predictions": sum(1 for t in judge_test_data if t["correct"]),
-        "accuracy_percentage": round((sum(1 for t in judge_test_data if t["correct"]) / len(judge_test_data) * 100), 1) if judge_test_data else 0,
-        "tests": judge_test_data
-    }
-    
-    with open("../output/judge_test_data.json", "w") as f:
-        json.dump(judge_test_file_data, f, indent=2, ensure_ascii=False)
-
-def get_random_match_for_testing() -> Tuple[Dict[str, Any], Dict[str, Any], str, str]:
-    """Get a random match from match history for judge testing."""
-    matches = load_match_history()
-    
-    if not matches:
-        return None, None, None, None
-    
-    match = random.choice(matches)
-    
-    story1_id = match["story1_id"]
-    story2_id = match["story2_id"]
-    winner_id = match["winner_id"]
-    
-    story1, story2 = None, None
-    for batch_name, stories in story_batches.items():
-        for story in stories:
-            if story["story_id"] == story1_id: story1 = story
-            elif story["story_id"] == story2_id: story2 = story
-    
-    if not story1 or not story2:
-        return None, None, None, None
-    
-    llm_winner_formatted = "story1" if winner_id == story1_id else "story2"
-    
-    return story1, story2, llm_winner_formatted, match
-
 def calculate_batch_stats(batch1_name: str, batch2_name: str) -> Dict[str, Any]:
-    """Calculate preference statistics between two batches."""
-    relevant_prefs = [
-        p for p in preference_data 
-        if (p['batch1'] == batch1_name and p['batch2'] == batch2_name) or
-           (p['batch1'] == batch2_name and p['batch2'] == batch1_name)
-    ]
+    """Calculate preference statistics between two batches from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT 
+            COUNT(*) as total,
+            SUM(CASE WHEN preferred_batch_name = ? THEN 1 ELSE 0 END) as b1_wins,
+            SUM(CASE WHEN preferred_batch_name = ? THEN 1 ELSE 0 END) as b2_wins
+        FROM human_preferences
+        WHERE (batch1_name = ? AND batch2_name = ?) OR (batch1_name = ? AND batch2_name = ?)
+    """, (batch1_name, batch2_name, batch1_name, batch2_name, batch2_name, batch1_name))
     
-    if not relevant_prefs:
-        return {"total_comparisons": 0}
+    row = cursor.fetchone()
+    if not row or row['total'] == 0:
+        return {"total_comparisons": 0, "batch1_wins": 0, "batch2_wins": 0, "batch1_percentage": 0, "batch2_percentage": 0}
     
-    batch1_wins = sum(1 for p in relevant_prefs if p.get('preferred_batch') == batch1_name)
-    batch2_wins = sum(1 for p in relevant_prefs if p.get('preferred_batch') == batch2_name)
-    
-    total = len(relevant_prefs)
-    batch1_percentage = (batch1_wins / total * 100) if total > 0 else 0
-    batch2_percentage = (batch2_wins / total * 100) if total > 0 else 0
+    total = row['total']
+    b1_wins = row['b1_wins'] or 0
+    b2_wins = row['b2_wins'] or 0
     
     return {
         "total_comparisons": total,
-        "batch1_wins": batch1_wins,
-        "batch2_wins": batch2_wins,
-        "batch1_percentage": round(batch1_percentage, 1),
-        "batch2_percentage": round(batch2_percentage, 1)
+        "batch1_wins": b1_wins,
+        "batch2_wins": b2_wins,
+        "batch1_percentage": round((b1_wins / total * 100), 1) if total > 0 else 0,
+        "batch2_percentage": round((b2_wins / total * 100), 1) if total > 0 else 0
     }
+
+def get_random_match_for_testing() -> Optional[Dict[str, Any]]:
+    """Get a random match from match history for judge testing."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM matches ORDER BY RANDOM() LIMIT 1")
+    match = cursor.fetchone()
+    if not match:
+        return None
+    
+    match_data = dict(match)
+    
+    cursor.execute("SELECT * FROM stories WHERE story_id IN (?, ?)", (match_data['story1_id'], match_data['story2_id']))
+    stories = {dict(row)['story_id']: dict(row) for row in cursor.fetchall()}
+    
+    if not stories or len(stories) != 2:
+        return None
+        
+    match_data['story1'] = stories[match_data['story1_id']]
+    match_data['story2'] = stories[match_data['story2_id']]
+    
+    return match_data
+
+# Global variables to hold transient state for a user's comparison
+current_comparison = None
+current_judge_test = None
 
 @app.route('/')
 def index():
     """Main page showing available batches and overall statistics."""
-    batch_names = list(story_batches.keys())
-    total_preferences = len(preference_data)
+    conn = get_db()
+    cursor = conn.cursor()
+    
+    batch_names = get_batch_names()
+    
+    cursor.execute("SELECT COUNT(*) FROM human_preferences")
+    total_preferences = cursor.fetchone()[0]
     
     batch_comparisons = {}
     if len(batch_names) >= 2:
@@ -289,9 +158,11 @@ def index():
             for batch2 in batch_names[i+1:]:
                 key = f"{batch1}_vs_{batch2}"
                 batch_comparisons[key] = calculate_batch_stats(batch1, batch2)
-    
-    total_judge_tests = len(judge_test_data)
-    correct_judge_tests = sum(1 for t in judge_test_data if t["correct"])
+
+    cursor.execute("SELECT COUNT(*), SUM(correct) FROM judge_tests")
+    total_tests, correct_tests = cursor.fetchone()
+    total_judge_tests = total_tests or 0
+    correct_judge_tests = correct_tests or 0
     judge_accuracy = round((correct_judge_tests / total_judge_tests * 100), 1) if total_judge_tests > 0 else 0
     
     return render_template('index.html', 
@@ -306,27 +177,27 @@ def compare_batches(batch1: str, batch2: str):
     """Compare stories from two different batches."""
     global current_comparison
     
-    if batch1 not in story_batches or batch2 not in story_batches:
-        return "Batch not found", 404
-    
-    story1, story2, b1, b2 = get_random_story_pair(batch1, batch2)
+    story1, story2, b1_name, b2_name = get_random_story_pair(batch1, batch2)
     
     if not story1 or not story2:
         return "No stories available for comparison", 404
     
-    if hash(story1['story_id'] + story2['story_id']) % 2 == 0:
-        story1, story2 = story2, story1
-        b1, b2 = b2, b1
+    # Randomize which story appears on the left (story A) vs right (story B)
+    if random.choice([True, False]):
+        storyA, storyB, batchA, batchB = story1, story2, b1_name, b2_name
+    else:
+        storyA, storyB, batchA, batchB = story2, story1, b2_name, b1_name
     
     current_comparison = {
-        "story1": story1, "story2": story2, "batch1": b1, "batch2": b2,
+        "storyA": storyA, "storyB": storyB, 
+        "batchA": batchA, "batchB": batchB,
         "original_batch1": batch1, "original_batch2": batch2
     }
     
     stats = calculate_batch_stats(batch1, batch2)
     
     return render_template('compare.html',
-                         story1=story1, story2=story2, batch1=b1, batch2=b2, stats=stats)
+                         story1=storyA, story2=storyB, batch1=batchA, batch2=batchB, stats=stats)
 
 @app.route('/submit_preference', methods=['POST'])
 def submit_preference():
@@ -337,21 +208,32 @@ def submit_preference():
         if not current_comparison:
             return jsonify({"error": "No active comparison"}), 400
         
-        preferred_story = request.json.get('preferred_story') if request.is_json else request.form.get('preferred_story')
-            
-        if preferred_story not in ['story1', 'story2']:
+        preferred_story_pos = request.json.get('preferred_story') # "story1" or "story2"
+        
+        if preferred_story_pos not in ['story1', 'story2']:
             return jsonify({"error": "Invalid preference"}), 400
+
+        story1 = current_comparison['storyA']
+        story2 = current_comparison['storyB']
         
-        user_session = request.headers.get('User-Agent', 'unknown')[:50]
-        original_batch1 = current_comparison['original_batch1']
-        original_batch2 = current_comparison['original_batch2']
-        preferred_batch = current_comparison['batch1'] if preferred_story == 'story1' else current_comparison['batch2']
-        mapped_preferred_story = 'story1' if preferred_batch == original_batch1 else 'story2'
-        
-        save_preference(
-            current_comparison['story1']['story_id'], current_comparison['story2']['story_id'],
-            original_batch1, original_batch2, mapped_preferred_story, user_session
-        )
+        if preferred_story_pos == 'story1':
+            preferred_id = story1['story_id']
+            preferred_batch = current_comparison['batchA']
+        else:
+            preferred_id = story2['story_id']
+            preferred_batch = current_comparison['batchB']
+
+        conn = get_db()
+        cursor = conn.cursor()
+        cursor.execute("""
+            INSERT INTO human_preferences (timestamp, story1_id, story2_id, preferred_story_id, user_session, batch1_name, batch2_name, preferred_batch_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """, (
+            datetime.now().isoformat(), story1['story_id'], story2['story_id'], preferred_id,
+            request.headers.get('User-Agent', 'unknown')[:100],
+            current_comparison['original_batch1'], current_comparison['original_batch2'], preferred_batch
+        ))
+        conn.commit()
         
         return jsonify({"success": True})
         
@@ -365,39 +247,52 @@ def next_comparison(batch1: str, batch2: str):
 
 @app.route('/reset_preferences', methods=['POST'])
 def reset_preferences():
-    """Reset all preference data."""
-    global preference_data
+    """Reset all human preference and judge test data."""
     try:
-        preference_data = []
-        for file_path in ["../output/preference_data.json", "../output/live_percentages.json"]:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-        return jsonify({"success": True, "message": "Preference data reset successfully"})
+        conn = get_db()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM human_preferences")
+        cursor.execute("DELETE FROM judge_tests")
+        conn.commit()
+        return jsonify({"success": True, "message": "All human-generated data has been reset."})
     except Exception as e:
-        return jsonify({"error": f"Failed to reset preferences: {e}"}), 500
+        return jsonify({"error": f"Failed to reset data: {e}"}), 500
 
 @app.route('/judge_test')
 def judge_test():
     """Test yourself against the LLM judge."""
     global current_judge_test
     
-    story1, story2, llm_winner, match_data = get_random_match_for_testing()
+    match_data = get_random_match_for_testing()
     
-    if not story1 or not story2:
+    if not match_data:
         return "No match history available for testing", 404
     
+    story1, story2 = match_data['story1'], match_data['story2']
+    llm_winner_id = match_data['winner_id']
+
+    # Randomize positions
     if random.choice([True, False]):
-        story1, story2 = story2, story1
-        llm_winner = "story2" if llm_winner == "story1" else "story1"
+        storyA, storyB = story1, story2
+        llm_winner_pos = "story1" if llm_winner_id == storyA['story_id'] else "story2"
+    else:
+        storyA, storyB = story2, story1
+        llm_winner_pos = "story1" if llm_winner_id == storyA['story_id'] else "story2"
+
+    current_judge_test = {
+        "storyA": storyA, "storyB": storyB, 
+        "llm_winner_pos": llm_winner_pos, "match_data": match_data
+    }
     
-    current_judge_test = {"story1": story1, "story2": story2, "llm_winner": llm_winner, "match_data": match_data}
-    
-    total_tests = len(judge_test_data)
-    correct_tests = sum(1 for t in judge_test_data if t["correct"])
+    cursor = get_db().cursor()
+    cursor.execute("SELECT COUNT(*), SUM(correct) FROM judge_tests")
+    total_tests, correct_tests = cursor.fetchone()
+    total_tests = total_tests or 0
+    correct_tests = correct_tests or 0
     accuracy = round((correct_tests / total_tests * 100), 1) if total_tests > 0 else 0
     
     return render_template('judge_test.html',
-                         story1=story1, story2=story2, total_tests=total_tests,
+                         story1=storyA, story2=storyB, total_tests=total_tests,
                          correct_tests=correct_tests, accuracy=accuracy)
 
 @app.route('/submit_judge_test', methods=['POST'])
@@ -407,36 +302,41 @@ def submit_judge_test():
     try:
         if not current_judge_test: return jsonify({"error": "No active judge test"}), 400
         
-        user_prediction = request.json.get('predicted_winner') if request.is_json else request.form.get('predicted_winner')
-        if user_prediction not in ['story1', 'story2']: return jsonify({"error": "Invalid prediction"}), 400
+        user_prediction_pos = request.json.get('predicted_winner') # story1 or story2
+        if user_prediction_pos not in ['story1', 'story2']: return jsonify({"error": "Invalid prediction"}), 400
         
-        user_session = request.headers.get('User-Agent', 'unknown')[:50]
-        llm_winner = current_judge_test["llm_winner"]
+        storyA = current_judge_test["storyA"]
+        storyB = current_judge_test["storyB"]
+        llm_winner_pos = current_judge_test["llm_winner_pos"]
+
+        user_prediction_id = storyA['story_id'] if user_prediction_pos == 'story1' else storyB['story_id']
+        llm_winner_id = storyA['story_id'] if llm_winner_pos == 'story1' else storyB['story_id']
+        correct = (user_prediction_id == llm_winner_id)
         
-        save_judge_test(user_prediction, llm_winner, current_judge_test["story1"]["story_id"],
-                        current_judge_test["story2"]["story_id"], user_session)
+        conn = get_db()
+        cursor = conn.cursor()
+        cursor.execute("""
+            INSERT INTO judge_tests (timestamp, story1_id, story2_id, user_prediction_id, llm_winner_id, correct, user_session)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (
+            datetime.now().isoformat(), storyA['story_id'], storyB['story_id'], user_prediction_id,
+            llm_winner_id, correct, request.headers.get('User-Agent', 'unknown')[:100]
+        ))
+        conn.commit()
         
-        correct = user_prediction == llm_winner
-        explanation = "Correct! You matched the LLM judge." if correct else f"Incorrect. The LLM judge preferred {'Story A' if llm_winner == 'story1' else 'Story B'}."
+        explanation = "Correct! You matched the LLM judge." if correct else f"Incorrect. The LLM judge preferred {'Story A' if llm_winner_pos == 'story1' else 'Story B'}."
         
-        return jsonify({"success": True, "correct": correct, "user_prediction": user_prediction,
-                        "llm_winner": llm_winner, "explanation": explanation})
+        return jsonify({"success": True, "correct": correct, "user_prediction": user_prediction_pos,
+                        "llm_winner": llm_winner_pos, "explanation": explanation})
     except Exception as e:
         return jsonify({"error": f"Server error: {e}"}), 500
 
 if __name__ == '__main__':
-    print("Loading story batches...")
-    story_batches = load_all_batches()
-    
-    if not story_batches:
-        print("No story batches found! Please run story generation first.")
+    if not os.path.exists(DB_PATH):
+        print(f"Database file not found at {DB_PATH}.")
+        print("Please run the evolution pipeline (`python evolve.py`) at least once to generate data.")
         exit(1)
-    
-    print(f"Loaded {len(story_batches)} batches: {list(story_batches.keys())}")
-    
-    load_preferences()
-    load_judge_test_data()
-    
+        
     print("Starting web server...")
     print("Visit http://localhost:8080 to use the preference testing interface")
     


### PR DESCRIPTION
This PR cleans up the project by replacing the JSON files with a single SQLite database and fixing the main pipeline logic.

The old way of using lots of separate JSON files was hard to manage. There was a `generate_final_batch` default where the pipeline would generate a final batch of stories but never run a tournament on them, which didn't fit the AlphaEvolve method. It was also really hard to read the winning files.

Here are the main changes:

1. Switched to a single SQLite database: All data (stories, matches, human preferences) is now stored in output/alphaevolve.db. This is much cleaner. The evolve.py --fresh command now just deletes this file to start over.

2. Fixed the pipeline logic: The pipeline now runs an initial generation and a first tournament. After that, it loops through "generate next batch -> run tournament". This ensures every batch of stories is judged.

3. Added final story export: After the last tournament is complete, the script now automatically saves the top 5 stories as simple, human-readable text files (e.g., rank_1_story.txt) in the output/ folder. This makes it easy to see the final winners.